### PR TITLE
fix: wrong name in namespace (green instead of red)

### DIFF
--- a/02-demo/01-red-riding-hood-v1/static/manifest-red.yaml
+++ b/02-demo/01-red-riding-hood-v1/static/manifest-red.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: green
+  name: red
 ---
 # Source: little-red-riding-hood-goldie/templates/body-server_sa.yaml
 apiVersion: v1


### PR DESCRIPTION
In static manifest 02-demo/01-red-riding-hood-v1/static/manifest-red.yaml it creates a namespace called green instead of red